### PR TITLE
feat: add conditional google analytics tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ SOCIAL_INSTAGRAM=https://www.instagram.com/username
 SITE_TITLE="Professional Portfolio"
 SITE_DESCRIPTION="Engineering leader specializing in system architecture, technical decision-making, and delivering measurable business impact."
 
+# Analytics (set to G-XXXXXXXXXX to enable Google Analytics)
+PUBLIC_GA_MEASUREMENT_ID=
+
 # Contact Form (Formspree)
 FORMSPREE_FORM_ID=your-form-id-here
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -91,6 +91,7 @@ export default defineConfig({
       SITE_LANGUAGE: envField.string({ context: 'client', access: 'public', default: 'en' }),
       SITE_TITLE: envField.string({ context: 'client', access: 'public', default: 'Professional Portfolio' }),
       SITE_DESCRIPTION: envField.string({ context: 'client', access: 'public', default: 'Engineering leader specializing in system architecture, technical decision-making, and delivering measurable business impact.' }),
+      PUBLIC_GA_MEASUREMENT_ID: envField.string({ context: 'client', access: 'public', default: '' }),
       
       // Author information
       SITE_AUTHOR_NAME: envField.string({ context: 'client', access: 'public', default: 'Your Name' }),

--- a/docs/02-configuration/configuration.md
+++ b/docs/02-configuration/configuration.md
@@ -14,6 +14,7 @@ Copy `.env.example` to `.env` and configure:
 | `SITE_LANGUAGE` | No | `en` | ISO 639-1 code (e.g., `en`, `id`, `de`) |
 | `SITE_TITLE` | No | `Professional Portfolio` | Site title for SEO |
 | `SITE_DESCRIPTION` | No | - | Default meta description |
+| `PUBLIC_GA_MEASUREMENT_ID` | No | - | Google Analytics measurement ID for site-wide analytics |
 
 ### Author Information
 
@@ -53,7 +54,15 @@ SITE_AUTHOR_LOCATION="San Francisco, CA"
 SOCIAL_GITHUB=https://github.com/johndoe
 SOCIAL_LINKEDIN=https://linkedin.com/in/johndoe
 SOCIAL_TWITTER=https://x.com/johndoe
+
+PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 ```
+
+## Google Analytics Setup
+
+Set `PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX` to enable Google Analytics across the site.
+
+Leave `PUBLIC_GA_MEASUREMENT_ID` empty to disable analytics and omit the Google Analytics scripts from the rendered pages.
 
 ## Navigation
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,9 +43,13 @@ import { ClientRouter } from 'astro:transitions';
 import Navigation from '../components/Navigation.astro';
 import Footer from '../components/Footer.astro';
 import { siteConfig } from '../config';
+import { createPageViewScript, hasMeasurementId, normalizeMeasurementId } from '../utils/googleAnalytics';
 import '../styles/global.css';
 import '../styles/typography.css';
 import '../styles/utilities.css';
+
+const measurementId = normalizeMeasurementId(import.meta.env.PUBLIC_GA_MEASUREMENT_ID);
+const hasGoogleAnalytics = hasMeasurementId(measurementId);
 ---
 
 <!DOCTYPE html>
@@ -84,6 +88,14 @@ import '../styles/utilities.css';
         e.newDocument.documentElement.setAttribute('data-theme', theme);
       });
     </script>
+
+    {hasGoogleAnalytics && (
+      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}></script>
+    )}
+
+    {hasGoogleAnalytics && (
+      <script is:inline set:html={createPageViewScript(measurementId)}></script>
+    )}
     
     <style>
       body {

--- a/src/utils/__tests__/googleAnalytics.test.ts
+++ b/src/utils/__tests__/googleAnalytics.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+const loadGoogleAnalytics = () => import('../googleAnalytics');
+
+describe('googleAnalytics', () => {
+  describe('normalizeMeasurementId', () => {
+    it('returns an empty string when the measurement id is undefined', async () => {
+      const { normalizeMeasurementId } = await loadGoogleAnalytics();
+
+      expect(normalizeMeasurementId(undefined)).toBe('');
+    });
+
+    it('trims surrounding whitespace from the measurement id', async () => {
+      const { normalizeMeasurementId } = await loadGoogleAnalytics();
+
+      expect(normalizeMeasurementId(' G-TEST123 ')).toBe('G-TEST123');
+    });
+  });
+
+  describe('createPageViewScript', () => {
+    it('generates an inline script that initializes gtag and tracks Astro page loads', async () => {
+      const { createPageViewScript } = await loadGoogleAnalytics();
+
+      const script = createPageViewScript('G-TEST123');
+
+      expect(script).toContain('window.dataLayer = window.dataLayer || [];');
+      expect(script).toContain('function gtag(){window.dataLayer.push(arguments);}');
+      expect(script).toContain("gtag('js', new Date());");
+      expect(script).toContain("gtag('config', 'G-TEST123', { send_page_view: false });");
+      expect(script).toContain("page_title: document.title");
+      expect(script).toContain("page_location: window.location.href");
+      expect(script).toContain("page_path: `${window.location.pathname}${window.location.search}`");
+      expect(script).toContain("document.addEventListener('astro:page-load', trackPageView);");
+    });
+
+    it('trims surrounding whitespace from the measurement id before generating the script', async () => {
+      const { createPageViewScript } = await loadGoogleAnalytics();
+
+      const script = createPageViewScript(' G-TEST123 ');
+
+      expect(script).toContain("gtag('config', 'G-TEST123', { send_page_view: false });");
+      expect(script).not.toContain("gtag('config', ' G-TEST123 ', { send_page_view: false });");
+    });
+  });
+
+  describe('hasMeasurementId', () => {
+    it('returns false for undefined', async () => {
+      const { hasMeasurementId } = await loadGoogleAnalytics();
+
+      expect(hasMeasurementId(undefined)).toBe(false);
+    });
+
+    it('returns false for an empty string', async () => {
+      const { hasMeasurementId } = await loadGoogleAnalytics();
+
+      expect(hasMeasurementId('')).toBe(false);
+    });
+
+    it('returns false for a whitespace-only string', async () => {
+      const { hasMeasurementId } = await loadGoogleAnalytics();
+
+      expect(hasMeasurementId('   \n\t  ')).toBe(false);
+    });
+
+    it('returns true for a non-empty measurement id', async () => {
+      const { hasMeasurementId } = await loadGoogleAnalytics();
+
+      expect(hasMeasurementId('G-TEST123')).toBe(true);
+    });
+  });
+
+  describe('getPageViewPayload', () => {
+    it('returns the pathname and query string when the URL has search params', async () => {
+      const { getPageViewPayload } = await loadGoogleAnalytics();
+
+      expect(getPageViewPayload('https://example.com/posts/astro?tag=analytics&page=2', 'Astro Analytics')).toEqual({
+        page_title: 'Astro Analytics',
+        page_location: 'https://example.com/posts/astro?tag=analytics&page=2',
+        page_path: '/posts/astro?tag=analytics&page=2',
+      });
+    });
+
+    it('returns only the pathname when the URL has no query string', async () => {
+      const { getPageViewPayload } = await loadGoogleAnalytics();
+
+      expect(getPageViewPayload('https://example.com/posts/astro', 'Astro Analytics')).toEqual({
+        page_title: 'Astro Analytics',
+        page_location: 'https://example.com/posts/astro',
+        page_path: '/posts/astro',
+      });
+    });
+  });
+});

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -1,0 +1,34 @@
+export function normalizeMeasurementId(measurementId?: string): string {
+  return measurementId?.trim() ?? '';
+}
+
+export function hasMeasurementId(measurementId?: string): measurementId is string {
+  return Boolean(normalizeMeasurementId(measurementId));
+}
+
+export function createPageViewScript(measurementId: string): string {
+  const escapedMeasurementId = normalizeMeasurementId(measurementId).replaceAll('\\', '\\\\').replaceAll("'", "\\'");
+
+  return `window.dataLayer = window.dataLayer || [];
+function gtag(){window.dataLayer.push(arguments);}
+function trackPageView() {
+  gtag('event', 'page_view', {
+    page_title: document.title,
+    page_location: window.location.href,
+    page_path: \`${'${window.location.pathname}'}${'${window.location.search}'}\`,
+  });
+}
+gtag('js', new Date());
+gtag('config', '${escapedMeasurementId}', { send_page_view: false });
+document.addEventListener('astro:page-load', trackPageView);`;
+}
+
+export function getPageViewPayload(href: string, title: string) {
+  const { pathname, search } = new URL(href);
+
+  return {
+    page_title: title,
+    page_location: href,
+    page_path: `${pathname}${search}`,
+  };
+}


### PR DESCRIPTION
## Summary
- add GA4 tracking to the shared Astro layout with conditional loading based on `PUBLIC_GA_MEASUREMENT_ID`
- track page views for initial loads and Astro client-side navigations while avoiding duplicate automatic page views
- document the new environment variable and add focused tests for analytics helper behavior

## Test Plan
- [x] npm run test:run
- [x] npm run check
- [x] npm run build
- [x] verified built output includes GA only when `PUBLIC_GA_MEASUREMENT_ID` is set